### PR TITLE
Fixed flaky test

### DIFF
--- a/generator/src/main/java/com/graphicsfuzz/generator/util/TransformationProbabilities.java
+++ b/generator/src/main/java/com/graphicsfuzz/generator/util/TransformationProbabilities.java
@@ -18,6 +18,8 @@ package com.graphicsfuzz.generator.util;
 
 import com.graphicsfuzz.common.util.IRandom;
 import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Comparator;
 
 public class TransformationProbabilities {
 
@@ -381,7 +383,13 @@ public class TransformationProbabilities {
   @Override
   public String toString() {
     String result = "";
-    for (Field field : this.getClass().getDeclaredFields()) {
+    Field[] sortedFields = this.getClass().getDeclaredFields();
+    Arrays.sort(sortedFields, new Comparator<Field>() {
+      public int compare(Field field1, Field field2) {
+        return field1.getName().compareTo(field2.getName());
+      }
+    });
+    for (Field field : sortedFields) {
       if (java.lang.reflect.Modifier.isStatic(field.getModifiers())) {
         continue;
       }

--- a/generator/src/test/java/com/graphicsfuzz/generator/util/TransformationProbabilitiesTest.java
+++ b/generator/src/test/java/com/graphicsfuzz/generator/util/TransformationProbabilitiesTest.java
@@ -24,20 +24,20 @@ public class TransformationProbabilitiesTest {
 
   @Test
   public void testToString() {
-    assertEquals("probSubstituteFreeVariable: 80\n"
+    assertEquals("probAddDeadFragColorWrites: 5\n"
+        + "probAddLiveFragColorWrites: 5\n"
         + "probDonateDeadCodeAtStmt: 5\n"
         + "probDonateLiveCodeAtStmt: 5\n"
+        + "probInjectDeadBarrierAtStmt: 5\n"
         + "probInjectJumpAtStmt: 5\n"
-        + "probWrapStmtInConditional: 5\n"
         + "probMutatePoint: 3\n"
-        + "probVectorizeStmts: 3\n"
+        + "probOutline: 5\n"
         + "probSplitLoops: 5\n"
         + "probStructify: 3\n"
-        + "probOutline: 5\n"
-        + "probAddLiveFragColorWrites: 5\n"
-        + "probAddDeadFragColorWrites: 5\n"
+        + "probSubstituteFreeVariable: 80\n"
         + "probSwitchify: 5\n"
-        + "probInjectDeadBarrierAtStmt: 5\n",
+        + "probVectorizeStmts: 3\n"
+        + "probWrapStmtInConditional: 5\n",
         TransformationProbabilities.SMALL_PROBABILITIES.toString());
   }
 


### PR DESCRIPTION
### Flakiness
**Nondex** was used to check and locate the flakiness in the test. The test can be reproduced using the following command:
```shell
mvn install -pl generator -am -DskipTests
mvn -pl generator test -Dtest=com.graphicsfuzz.generator.util.TransformationProbabilitiesTest#testToString
mvn -pl generator edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=com.graphicsfuzz.generator.util.TransformationProbabilitiesTest#testToString
``` 

### Issue
In the `toString` method, `getDeclaredFields()` was called to iterate through all the fields in this class. However, `getDeclaredFields()` does not guarantee the order of elements returned, according to the [Java Documentation](https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html#getDeclaredFields--): The elements in the returned array are not sorted and are not in any particular order.
## Fix
Since the output array of `getDeclaredFields()` is not in any particular order, the fix sorts the array of fields returned by `getDeclaredFields()`  by field name and then convert the array to string with the original format, except that fields are sorted by name. In the testcase, the expected string is also sorted by field names. This way this testcase constantly passes, resolving any flakiness. 